### PR TITLE
bind::zone: add ability for update-policy{}

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -28,10 +28,11 @@
 #
 define bind::zone (
   $target,
-  $tag        = $name, # tag each zone with its name unless a tag is provided
-  $extra_path = undef, # optional extra dir structure - must be absolute, ie '/internal'
-  $masters    = undef, # if type is slave, this must be specified, else ignored
-  $type       = undef, # master or slave
+  $tag             = $name, # tag each zone with its name unless a tag is provided
+  $extra_path      = undef, # optional extra dir structure - must be absolute, ie '/internal'
+  $masters         = undef, # if type is slave, this must be specified, else ignored
+  $type            = undef, # master or slave
+  $update_policies = undef,
 ) {
 
   include ::bind
@@ -59,6 +60,10 @@ define bind::zone (
 
   if ($masters != undef) and (is_string($masters) == false) {
     fail('bind::zone::masters is not a string')
+  }
+
+  if $update_policies != undef {
+    validate_hash($update_policies)
   }
 
   $dir = $type ? {

--- a/spec/defines/zone_spec.rb
+++ b/spec/defines/zone_spec.rb
@@ -237,6 +237,12 @@ describe 'bind::zone' do
         :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false],
         :message => 'is not a string',
       },
+      'hash' => {
+        :name    => %w(update_policies),
+        :valid   => [{ 'ha' => 'sh' }],
+        :invalid => ['string', 3, 2.42, %w(array), true, false, nil],
+        :message => 'is not a Hash',
+      },
     }
 
     validations.sort.each do |type, var|

--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -7,4 +7,13 @@ zone "<%= @name %>" {
   masters { <%= @masters %>; };
 <% end -%>
   file "<%= @dir %><% if not @extra_path.nil? -%><%= @extra_path%><% end -%>/<%= @name %>";
+<% if not @update_policies.nil? -%>
+
+  update-policy
+  {
+<%   @update_policies.sort.each do |k,v| -%>
+    grant <%= v['key'] -%> <%= v['matchtype'] -%> <%= k -%>.<% if not v['rrs'].nil? and v['rrs'].empty? == false -%> <%= v['rrs'].join(' ') -%><% end -%>;
+<%   end -%>
+  };
+<% end -%>
 };


### PR DESCRIPTION
Allows for matchtype of name and subdomain with optionally specifying
resource records.

Add update_policy parameter to bind::zone which, if specified, must be a
hash in the following format. Note that matchtype and key are mandatory
and rrs is an optional array.

bind::zones:
  'example.com':
    type: 'master'
    target: '/etc/named/zone_lists/internal.zones'
    tag: 'internal'
    extra_path: '/internal'
    update_policies:
      'dev.example.com':
        matchtype: 'subdomain'
        key: 'key-internal'
      'foo.example.com':
        matchtype: 'name'
        key: 'some-key'
        rrs:
          - 'CNAME'

would result in

zone "example.com" {
  type master;
  file "master/internal/example.com";

  update-policy
  {
    grant key-internal subdomain dev.example.com.;
    grant some-key name foo.example.com. CNAME;
  };
};