### PR TITLE
bind::zone puts zones in extra_path to allow for views

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,8 @@
 fixtures:
   repositories:
+    common:
+      repo: 'https://github.com/ghoneycutt/puppet-module-common.git'
+      ref: 'v1.6.0'
     concat:
       repo: 'https://github.com/puppetlabs/puppetlabs-concat.git'
       ref: '2.1.0'

--- a/metadata.json
+++ b/metadata.json
@@ -39,6 +39,7 @@
     }
   ],
   "dependencies": [
+    {"name":"ghoneycutt-common","version_requirement":">= 1.6.0 < 2.0.0"},
     {"name":"puppetlabs-concat","version_requirement":">= 2.1.0 < 3.0.0"},
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
   ]

--- a/spec/defines/zone_spec.rb
+++ b/spec/defines/zone_spec.rb
@@ -39,21 +39,23 @@ describe 'bind::zone' do
     it { should compile.with_all_deps }
     it { should contain_class('bind') }
 
+    it { should contain_common__mkdir_p('/etc/named/zones.d/internal') }
+
     it do
-      should contain_file('/etc/named/zones.d/rspec').with({
+      should contain_file('/etc/named/zones.d/internal/rspec').with({
         'ensure'  => 'file',
         'content' => content,
         'owner'   => 'named',
         'group'   => 'named',
         'mode'    => '0640',
-        'require' => 'Package[bind]',
+        'require' => ['Package[bind]','Common::Mkdir_p[/etc/named/zones.d/internal]'],
       })
     end
 
     it do
       should contain_concat_fragment('bind::zone::rspec').with({
         'target'  => '/etc/named/zone_lists/internal.zones',
-        'content' => 'include "/etc/named/zones.d/rspec";',
+        'content' => 'include "/etc/named/zones.d/internal/rspec";',
         'tag'     => 'internal',
       })
     end
@@ -110,7 +112,7 @@ describe 'bind::zone' do
 
     it { should compile.with_all_deps }
     it { should contain_class('bind') }
-    it { should contain_file('/etc/named/zones.d/rspec').with_content(content) }
+    it { should contain_file('/etc/named/zones.d/SPECtacular/rspec').with_content(content) }
   end
 
   context 'with masters set to valid <master-spec> and type set to <master>' do


### PR DESCRIPTION
You could have multiple instances of the same zone if you use views, so
this allows for that by allowing the zones to be placed in different
places.