### PR TITLE
Add specs for main class - Part 2

### DIFF
--- a/spec/fixtures/hiera/common.yaml
+++ b/spec/fixtures/hiera/common.yaml
@@ -1,0 +1,5 @@
+---
+bind::channels:
+  'from_hiera_common':
+    'type': 'file'
+    'file': 'satisfy bind::channel'

--- a/spec/fixtures/hiera/fqdn/hiera-channels.example.local.yaml
+++ b/spec/fixtures/hiera/fqdn/hiera-channels.example.local.yaml
@@ -1,0 +1,5 @@
+---
+bind::channels:
+  'from_hiera_fqdn':
+    'type': 'file'
+    'file': 'satisfy bind::channel'

--- a/spec/fixtures/hiera/hiera.yaml
+++ b/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: 'spec/fixtures/hiera'
+:hierarchy:
+  - fqdn/%{fqdn}
+  - common


### PR DESCRIPTION
@ghoneycutt adding more spec tests for the main class.

I think there are issues with the hiera merge functionality.
<pre>
  if $channels != undef {
    if $channels_hiera_merge_real == true {
      $channels_real = hiera_hash('bind::channels')
    } else {
      $channels_real = $channels
    }
    validate_hash($channels_real)
    create_resources('bind::channel', $channels_real)
  }
</pre>

- $channels set while calling will be ignored if hiera merge is true
  - should merged data from $channels too
- hiera data will be ignored completely when hiera merge is false
  - should use the most specific data from hiera and merge with data from $channels
- (you need to have set $channels to reach hiera merge functionality at all)
  - unsure myself at the moment if this is an issue

Please check my corrosponding tests ('with channels set to valid hash') to see the current results.
