### PR TITLE
Fix spec test when run on MacOSX

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -810,6 +810,7 @@ describe 'bind' do
     let(:facts) do
       {
         :osfamily => 'RedHat',
+        :operatingsystem => 'RedHat',
       }
     end
     # /!\ template does not support $include = undef


### PR DESCRIPTION
Without this patch, running the spec test on Mac OS X would fail with the
following error:

     Failure/Error: it { should compile }
       error during compilation: Parameter ensure failed on Package[bind]: Provider must have features 'versionable' to set 'ensure' to 'string' at
     # ./spec/classes/init_spec.rb:904:in `block (7 levels) in <top (required)>'

This patch causes the correct package provider to be used during the spec
testing.