### PR TITLE
Docs refactor to cgroups style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,27 @@ language: ruby
 
 rvm:
   - 1.8.7
+  - 1.9.3
+  - 2.0.0
   - 2.1.0
+  - 2.3.1
 
 env:
   matrix:
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
     - PUPPET_GEM_VERSION="~> 3.8.0"
     - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-    - PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4.3.0"
+    - PUPPET_GEM_VERSION="~> 4.4.0"
+    - PUPPET_GEM_VERSION="~> 4.5.0"
+    - PUPPET_GEM_VERSION="~> 4.6.0"
+    - PUPPET_GEM_VERSION="~> 4.7.0"
+    - PUPPET_GEM_VERSION="~> 4"
 
 sudo: false
 
@@ -19,7 +33,33 @@ matrix:
   fast_finish: true
   exclude:
     - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4" STRICT_VARIABLES="yes"
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.3.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.5.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.6.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.7.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.5.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.6.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.7.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.8.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source ENV['GEM_SOURCE'] || "https://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
@@ -7,16 +7,15 @@ else
 end
 
 gem 'metadata-json-lint'
-gem 'puppetlabs_spec_helper', '>= 1.1.1'
-gem 'puppet-lint', '>= 1.0.0'
+gem 'puppetlabs_spec_helper', '>= 1.2.0'
 gem 'facter', '>= 1.7.0'
-gem 'rspec-puppet', '~> 2.0'
+gem 'rspec-puppet'
+gem 'puppet-lint', '~> 2.0'
 gem 'puppet-lint-absolute_classname-check'
 gem 'puppet-lint-alias-check'
 gem 'puppet-lint-empty_string-check'
 gem 'puppet-lint-file_ensure-check'
 gem 'puppet-lint-file_source_rights-check'
-gem 'puppet-lint-fileserver-check'
 gem 'puppet-lint-leading_zero-check'
 gem 'puppet-lint-spaceship_operator_without_tag-check'
 gem 'puppet-lint-trailing_comma-check'
@@ -24,16 +23,7 @@ gem 'puppet-lint-undef_in_function-check'
 gem 'puppet-lint-unquoted_string-check'
 gem 'puppet-lint-variable_contains_upcase'
 
-if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
-  # rspec must be v2 for ruby 1.8.7
-  gem 'rspec', '~> 2.0'
-  # rake must be v10 for ruby 1.8.7
-  gem 'rake', '~> 10.0'
-end
-
-if RUBY_VERSION < '2.0'
-  # json 2.x requires ruby 2.0. Lock to 1.8
-  gem 'json', '~> 1.8'
-  # json_pure 2.0.2 requires ruby 2.0. Lock to 2.0.1
-  gem 'json_pure', '= 2.0.1'
-end
+gem 'rspec',     '~> 2.0'   if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+gem 'rake',      '~> 10.0'  if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+gem 'json',      '<= 1.8'   if RUBY_VERSION < '2.0.0'
+gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ to your bind masters.
 
 # Compatibility
 
-This module has been tested to work on the following systems with Puppet
-versions v3, v3 with future parser and v4 with Ruby versions 1.8.7 (Puppet v3
-only) and 2.1.0.
+This module is built for use with Puppet v3 (with and without the future
+parser) and Puppet v4 on the following platforms and supports Ruby versions
+1.8.7, 1.9.3, 2.0.0, 2.1.0 and 2.3.1.
 
  * EL 6
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
 # puppet-module-bind
 
+#### Table of Contents
+
+1. [Module Description](#module-description)
+2. [Compatibility](#compatibility)
+3. [Class Descriptions](#class-descriptions)
+    * [bind](#class-bind)
+4. [Define Descriptions](#define-descriptions)
+    * [bind::acl](#defined-type-bindacl)
+    * [bind::channel](#defined-type-bindchannel)
+    * [bind::key](#defined-type-bindkey)
+    * [bind::masters](#defined-type-bindmasters)
+    * [bind::view](#defined-type-bindview)
+    * [bind::zone](#defined-type-bindzone)
+
+# Module description
+
 Manage ISC Bind 9. This module's approach is to manage the configuration of
 bind9 while not managing the data in the actual zones, which is up to you.
 Recommend keeping zone data in another repo and having a process sync that data
 to your bind masters.
-
-===
 
 # Compatibility
 
@@ -15,417 +29,423 @@ only) and 2.1.0.
 
  * EL 6
 
-===
+[![Build Status](https://travis-ci.org/ghoneycutt/puppet-module-bind.png?branch=master)](https://travis-ci.org/ghoneycutt/puppet-module-bind)
 
-# Parameters for `class bind`
+# Class Descriptions
+## Class `bind`
 
-package (type: String)
+### Description
+
+/!\ TODO: need description
+
+### Parameters
+
 ---
+#### package (type: String)
 Package to be installed for ISC Bind 9.
 
 - *Default*: 'bind-chroot'
 
-package_ensure (type: String)
 ---
+#### package_ensure (type: String)
 Value of ensure attribute for bind package.
 
 - *Default*: 'present'
 
-config_path (type: String)
 ---
+#### config_path (type: String)
 Absolute path to named.conf.
 
 - *Default*: '/etc/named.conf'
 
-config_dir (type: String)
 ---
+#### config_dir (type: String)
 Absolute path to configuration directory.
 
 - *Default*: '/etc/named'
 
-rndc_key (type: String)
 ---
+#### rndc_key (type: String)
 Absolute path to RNDC key.
 
 - *Default*: '/etc/rndc.key'
 
-rndc_key_secret (type: String)
 ---
+#### rndc_key_secret (type: String)
 Secret for rndc_key.
 
 - *Default*: 'U803nlXs4b5x6t7UDw8hnw
 
-service (type: String)
 ---
+#### service (type: String)
 Name of bind service.
 
 - *Default*: 'named'
 
-user (type: String)
 ---
+#### user (type: String)
 Bind user.
 
 - *Default*: 'named'
 
-group (type: String)
 ---
+#### group (type: String)
 Bind group.
 
 - *Default*: 'named'
 
-named_checkconf (type: String)
 ---
+#### named_checkconf (type: String)
 Absolute path to named-checkconf.
 
 - *Default*: '/usr/sbin/named-checkconf'
 
-version (type: String)
 ---
+#### version (type: String)
 Version to be announced. This is queryable, so recommend not using the actual
 version.
 
 - *Default*: 'notsoeasy'
 
-notify_option (type: String)
 ---
+#### notify_option (type: String)
 Value of `notify` option in named.conf.
 
 - *Default*: 'no'
 
-recursion (type: String)
 ---
+#### recursion (type: String)
 Value of `recursion` option in named.conf.
 
 - *Default*: 'no'
 
-zone_statistics (type: String)
 ---
+#### zone_statistics (type: String)
 Value of `zone-statistics` option in named.conf.
 
 - *Default*: 'yes'
 
-allow_query (type: String)
 ---
+#### allow_query (type: String)
 Value of `allow-query` option in named.conf.
 
 - *Default*: 'any'
 
-allow_transfer (type: String)
 ---
+#### allow_transfer (type: String)
 Value of `allow-transfer` option in named.conf.
 
 - *Default*: 'none'
 
-cleaning_interval (type: Integer)
 ---
+#### cleaning_interval (type: Integer)
 Value of `cleaning-interval` option in named.conf.
 
 - *Default*: 1440
 
-check_names (type: String)
 ---
+#### check_names (type: String)
 Value used in `check-names` option in named.conf. The template will add the
 type (master or slave) based on the `type` parameter. Valid values are 'fail',
 'ignore' and 'warn'.
 
 - *Default*: 'ignore'
 
-port (type: Integer)
 ---
+#### port (type: Integer)
 Value used in `listen-on` option in named.conf.
 
 - *Default*: 53
 
-listen_from (type: String)
 ---
+#### listen_from (type: String)
 Value used in `listen-on` option in named.conf.
 
 - *Default*: 'any'
 
-dnssec_enable (type: String)
 ---
+#### dnssec_enable (type: String)
 Value of `dnssec-enable` option in named.conf.
 
 - *Default*: 'no'
 
-dnssec_validation (type: String)
 ---
+#### dnssec_validation (type: String)
 Value of `dnssec-validation` option in named.conf.
 
 - *Default*: 'no'
 
-directory (type: String)
 ---
+#### directory (type: String)
 Value of `directory` option in named.conf.
 
 - *Default*: '/var/named'
 
-dump_file (type: String)
 ---
+#### dump_file (type: String)
 Value of `dump-file` option in named.conf.
 
 - *Default*: '/var/named/data/cache_dump.db'
 
-statistics_file (type: String)
 ---
+#### statistics_file (type: String)
 Value of `statistics-file` option in named.conf.
 
 - *Default*: '/var/named/data/named_stats.txt'
 
-memstatistics_file (type: String)
 ---
+#### memstatistics_file (type: String)
 Value of `memstatistics-file` option in named.conf.
 
 - *Default*: '/var/named/data/named_mem_stats.txt'
 
-type (type: String)
 ---
+#### type (type: String)
 Type of bind system. Valid values are 'master' and 'slave'.
 
 - *Default*: 'master'
 
-default_logging_channel (type: String)
 ---
+#### default_logging_channel (type: String)
 Name of default logging channel to use. Valid values are 'default_syslog',
 'default_debug', 'default_stderr' and 'null'.
 
 - *Default*: 'default_syslog'
 
-use_default_logging_channel (type: Boolean)
 ---
+#### use_default_logging_channel (type: Boolean)
 Determines if bind::channel should be called for the `default_logging_channel`.
 
 - *Default*: true
 
-enable_logging_category_default (type: Boolean)
 ---
+#### enable_logging_category_default (type: Boolean)
 Determine if the logging category `default` should be enabled.
 
 - *Default*: false
 
-logging_category_default_channels (type: Array)
 ---
+#### logging_category_default_channels (type: Array)
 List of channels for logging category `default`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_general (type: Boolean)
 ---
+#### enable_logging_category_general (type: Boolean)
 Determine if the logging category `general` should be enabled.
 
 - *Default*: false
 
-logging_category_general_channels (type: Array)
 ---
+#### logging_category_general_channels (type: Array)
 List of channels for logging category `general`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_config (type: Boolean)
 ---
+#### enable_logging_category_config (type: Boolean)
 Determine if the logging category `config` should be enabled.
 
 - *Default*: false
 
-logging_category_config_channels (type: Array)
 ---
+#### logging_category_config_channels (type: Array)
 List of channels for logging category `config`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_client (type: Boolean)
 ---
+#### enable_logging_category_client (type: Boolean)
 Determine if the logging category `client` should be enabled.
 
 - *Default*: false
 
-logging_category_client_channels (type: Array)
 ---
+#### logging_category_client_channels (type: Array)
 List of channels for logging category `client`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_database (type: Boolean)
 ---
+#### enable_logging_category_database (type: Boolean)
 Determine if the logging category `database` should be enabled.
 
 - *Default*: false
 
-logging_category_database_channels (type: Array)
 ---
+#### logging_category_database_channels (type: Array)
 List of channels for logging category `database`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_network (type: Boolean)
 ---
+#### enable_logging_category_network (type: Boolean)
 Determine if the logging category `network` should be enabled.
 
 - *Default*: false
 
-logging_category_network_channels (type: Array)
 ---
+#### logging_category_network_channels (type: Array)
 List of channels for logging category `network`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_notify (type: Boolean)
 ---
+#### enable_logging_category_notify (type: Boolean)
 Determine if the logging category `notify` should be enabled.
 
 - *Default*: false
 
-logging_category_notify_channels (type: Array)
 ---
+#### logging_category_notify_channels (type: Array)
 List of channels for logging category `notify`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_queries (type: Boolean)
 ---
+#### enable_logging_category_queries (type: Boolean)
 Determine if the logging category `queries` should be enabled.
 
 - *Default*: false
 
-logging_category_queries_channels (type: Array)
 ---
+#### logging_category_queries_channels (type: Array)
 List of channels for logging category `queries`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_security (type: Boolean)
 ---
+####enable_logging_category_security (type: Boolean)
 Determine if the logging category `security` should be enabled.
 
 - *Default*: false
 
-logging_category_security_channels (type: Array)
 ---
+#### logging_category_security_channels (type: Array)
 List of channels for logging category `security`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_resolver (type: Boolean)
 ---
+#### enable_logging_category_resolver (type: Boolean)
 Determine if the logging category `resolver` should be enabled.
 
 - *Default*: false
 
-logging_category_resolver_channels (type: Array)
 ---
+#### logging_category_resolver_channels (type: Array)
 List of channels for logging category `resolver`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_update (type: Boolean)
 ---
+#### enable_logging_category_update (type: Boolean)
 Determine if the logging category `update` should be enabled.
 
 - *Default*: false
 
-logging_category_update_channels (type: Array)
 ---
+#### logging_category_update_channels (type: Array)
 List of channels for logging category `update`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_update_security (type: Boolean)
 ---
+#### enable_logging_category_update_security (type: Boolean)
 Determine if the logging category `update-security` should be enabled.
 
 - *Default*: false
 
-logging_category_update_security_channels (type: Array)
 ---
+#### logging_category_update_security_channels (type: Array)
 List of channels for logging category `update-security`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_xfer_in (type: Boolean)
 ---
+#### enable_logging_category_xfer_in (type: Boolean)
 Determine if the logging category `xfer-in` should be enabled.
 
 - *Default*: false
 
-logging_category_xfer_in_channels (type: Array)
 ---
+#### logging_category_xfer_in_channels (type: Array)
 List of channels for logging category `xfer-in`.
 
 - *Default*: ['default_syslog']
 
-enable_logging_category_xfer_out (type: Boolean)
 ---
+#### enable_logging_category_xfer_out (type: Boolean)
 Determine if the logging category `xfer-out` should be enabled.
 
 - *Default*: false
 
-logging_category_xfer_out_channels (type: Array)
 ---
+#### logging_category_xfer_out_channels (type: Array)
 List of channels for logging category `xfer-out`.
 
 - *Default*: ['default_syslog']
 
-channels_dir (type: String)
 ---
+#### channels_dir (type: String)
 Absolute path to directory which will contain the channel snippets.
 
 - *Default*: '/etc/named/channels.d'
 
-channels_list (type: String)
 ---
+#### channels_list (type: String)
 Absolute path to file which will contain the list of channel snippets.
 
 - *Default*: '/etc/named/channels'
 
-channels (type: Hash or undef)
 ---
+#### channels (type: Hash or undef)
 Hash of bind::channel resources.
 
 - *Default*: undef
 
-channels_hiera_merge (type: Boolean)
 ---
+#### channels_hiera_merge (type: Boolean)
 Determine if the `channels` parameter should be populated using Hiera's merge
 lookup.
 
 - *Default*: true
 
-acls_dir (type: String)
 ---
+#### acls_dir (type: String)
 Absolute path to directory which will contain the acl snippets.
 
 - *Default*: '/etc/named/acls.d'
 
-acls_list (type: String)
 ---
+#### acls_list (type: String)
 Absolute path to file which will contain the list of acl snippets.
 
 - *Default*: '/etc/named/acls'
 
-acls (type: Hash or undef)
 ---
+#### acls (type: Hash or undef)
 Hash of `bind::acl` resources.
 
 - *Default*: undef
 
-acls_hiera_merge (type: Boolean)
 ---
+#### acls_hiera_merge (type: Boolean)
 Determine if the `acls` parameter should be populated using Hiera's merge
 lookup.
 
 - *Default*: true
 
-controls (type: Hash or undef)
---------
+---
+#### controls (type: Hash or undef)
 Specifies information for controls lines in the named.conf. The key is the IP
 address or `'*'`. The hash has subkeys that must include 'port' (string),
 'allows' (array) and optionally 'keys' (array).
 
 - *Default*: undef
 
-```
-# example
-
+##### Example:
+```yaml
 bind::controls:
   '*':
     port: '953'
@@ -434,226 +454,226 @@ bind::controls:
     keys:
       - 'rndc-key'
 ```
-
-keys (type: Hash or undef)
 ---
+#### keys (type: Hash or undef)
 Hash of `bind::key` resources.
 
 - *Default*: undef
 
-keys_hiera_merge (type: Boolean)
 ---
+#### keys_hiera_merge (type: Boolean)
 Determine if the `keys` parameter should be populated using Hiera's merge
 lookup.
 
 - *Default*: true
 
-keys_list (type: String)
 ---
+#### keys_list (type: String)
 Absolute path to file which will contain the list of key snippets.
 
 - *Default*: '/etc/named/keys'
 
-masters_dir (type: String)
 ---
+#### masters_dir (type: String)
 Absolute path to directory which will contain the master snippets.
 
 - *Default*: '/etc/named/masters.d'
 
-masters_list (type: String)
 ---
+#### masters_list (type: String)
 Absolute path to file which will contain the list of master snippets.
 
 - *Default*: '/etc/named/masters'
 
-masters (type: Hash or undef)
 ---
+#### masters (type: Hash or undef)
 Hash of `bind::master` resources.
 
 - *Default*: undef
 
-masters_hiera_merge (type: Boolean)
 ---
+#### masters_hiera_merge (type: Boolean)
 Determine if the `masters` parameter should be populated using Hiera's merge
 lookup.
 
 - *Default*: true
 
-views_dir (type: String)
 ---
+#### views_dir (type: String)
 Absolute path to directory which will contain the view snippets.
 
 - *Default*: '/etc/named/views.d'
 
-views_list (type: String)
 ---
+#### views_list (type: String)
 Absolute path to file which will contain the list of view snippets.
 
 - *Default*: '/etc/named/views'
 
-views (type: Hash or undef)
 ---
+#### views (type: Hash or undef)
 Hash of `bind::view` resources.
 
 - *Default*: undef
 
-views_hiera_merge (type: Boolean)
 ---
+#### views_hiera_merge (type: Boolean)
 Determine if the `views` parameter should be populated using Hiera's merge
 lookup.
 
 - *Default*: true
 
-zones_dir (type: String)
 ---
+#### zones_dir (type: String)
 Absolute path to directory which will contain the zone snippets.
 
 - *Default*: '/etc/named/zones.d'
 
-zones_hiera_merge (type: Boolean)
 ---
+#### zones_hiera_merge (type: Boolean)
 Determine if the `zones` parameter should be populated using Hiera's merge
 lookup.
 
 - *Default*: true
 
-zones (type: Hash or undef)
 ---
+#### zones (type: Hash or undef)
 Hash of `bind::zone` resources.
 
 - *Default*: undef
 
-zone_lists_dir (type: String)
 ---
+#### zone_lists_dir (type: String)
 Absolute path to directory which will contain the zone lists.
 
 - *Default*: '/etc/named/zone_lists'
 
-===
+---
 
-# Parameters for `define bind::acl`
+# Define Descriptions
+## Defined type `bind::acl`
+
+### Description
 
 Manage acl declarations.
 
 Must specify at least one of `entries` and `keys`.
 
-name (type: String)
-----
+### Parameters
+
+---
+#### name (type: String)
 Unique name of the `acl` declaration.
 
-entries (type: Array or undef)
 ---
+#### entries (type: Array or undef)
 List of entries for an `acl` declaration.
 
 - *Default*: undef
 
-keys (type: Array or undef)
 ---
+#### keys (type: Array or undef)
 List of keys for an `acl` declaration.
 
 - *Default*: undef
 
-===
+---
 
-# Parameters for `define bind::channel`
+## Defined type `bind::channel`
+
+### Description
 
 Manage a channel declaration. The types are fundamentally those of files or
-syslog, so one of `syslog_facility` and `files` must be populated.
+syslog, so one of `syslog_facility` and `file` must be populated.
 
-name (type: String)
----
-Name of logging channel.
-
-type (type: String)
----
-Type of logging channel. Valid values are 'file', 'syslog', 'stderr' and 'null'.
-
-- *Required*
-
-file (type: String)
----
-Value of `file` option for channel. May be a relative path.
-
-- *Default*: undef
-
-severity (type: String)
----
-Value of `severity` option for channel.
-
-- *Default*: undef
-
-syslog_facility (type: String)
----
-Value of `syslog` option for channel.
-
-- *Default*: undef
-
-```
-# example
-
+##### Example:
+```yaml
 bind::channels:
   'my_syslog':
     type: 'syslog'
     syslog_facility: 'daemon'
     severity: 'info'
 ```
-===
-
-# Parameters for `define bind::key`
-
-Manage a key declaration.
-
-name (type: String)
 ---
-Name of key.
 
-secret (type: String)
+### Parameters
+
 ---
-Value of `secret` option for key.
+#### name (type: String)
+Name of logging channel.
+
+---
+#### type (type: String)
+Type of logging channel. Valid values are 'file', 'syslog', 'stderr' and 'null'.
 
 - *Required*
 
-algorithm (type: String)
 ---
-Value of `algorithm` option for key.
+#### file (type: String)
+Value of `file` option for channel. May be a relative path.
 
-- *Default*: 'hmac-md5'
+- *Default*: undef
 
-path (type: Integer)
 ---
-Absolute path to file containing the key declaration.
+#### severity (type: String)
+Value of `severity` option for channel.
 
-- *Default*: "/etc/named/{name}.key"
+- *Default*: undef
 
-```
-# example
+---
+#### syslog_facility (type: String)
+Value of `syslog` option for channel.
+
+- *Default*: undef
+
+## Defined type `bind::key`
+
+### Description
+
+Manage a key declaration.
+
+##### Example:
+```yaml
 bind::keys:
   'key-external-transfer':
     secret: 'generated_secret'
   'key-internal-transfer':
     secret: 'generated_secret'
 ```
-
-===
-
-# Parameters for `define bind::masters`
-
-Manage a masters declaration.
-
-name (type: String)
 ---
-Name of masters declaration.
 
-entries (type: )
+### Parameters
+
 ---
-Hash of entries for masters declaration. The key is the IP address and the
-value is the name of a key.
+#### name (type: String)
+Name of key.
+
+---
+#### secret (type: String)
+Value of `secret` option for key.
 
 - *Required*
 
-```
-# example
+---
+#### algorithm (type: String)
+Value of `algorithm` option for key.
 
+- *Default*: 'hmac-md5'
+
+---
+#### path (type: Integer)
+Absolute path to file containing the key declaration.
+
+- *Default*: "/etc/named/${name}.key"
+
+## Defined type `bind::masters`
+
+### Description
+
+Manage a masters declaration.
+
+##### Example:
+```yaml
 bind::masters:
   'masters-external':
     entries:
@@ -663,57 +683,29 @@ bind::masters:
       '10.3.2.1': 'key-internal'
       '10.3.2.2': 'key-internal'
 ```
-
-===
-
-# Parameters for `define bind::view`
-
-match_clients (type: String)
 ---
 
+### Parameters
 
-- *Default*: 'any'
-
-recursion (type: )
 ---
+#### name (type: String)
+Name of masters declaration.
 
-
-- *Default*: undef
-
-includes (type: )
 ---
+#### entries (type: Hash )
+Hash of entries for masters declaration. The key is the IP address and the
+value is the name of a key.
 
+- *Required*
 
-- *Default*: undef
+## Defined type `bind::view`
 
-allow_update (type: )
----
+### Description
 
+/!\ TODO add descriptionm
 
-- *Default*: undef
-
-allow_update_forwarding (type: )
----
-
-
-- *Default*: undef
-
-allow_transfer (type: )
----
-
-
-- *Default*: undef
-
-order (type: )
----
-
-
-- *Default*: undef
-
-
-```
-# example
-
+### Example
+```yaml
 bind::views:
   'corp-internal':
     order: 10
@@ -728,55 +720,49 @@ bind::views:
     allow_transfer: 'internal-transfer'
 ```
 
-===
+### Parameters
 
-# Parameters for `define bind::zone`
-
-target (type: String)
 ---
-Absolute path to zone list file which is the target of concat_fragment.
+#### match_clients (type: String)
+- *Default*: 'any'
 
-- *Required*
-
-tag (type: Integer)
 ---
-Tag to be used with concat_fragment.
-
-- *Default*: $name
-
-extra_path (type: String)
----
-Optional extra path to be appended to `$bind::zones_dir`. Must be an absolute
-path.
+#### recursion (type: String)
+Valid values are 'yes' and 'no'.
 
 - *Default*: undef
 
-masters (type: Integer)
 ---
-Value of `masters` config option in a zone declaration. If `type` is 'slave',
-this is required, else it is not used.
+#### includes (type: Array)
+- *Default*: undef
+
+---
+#### allow_update (type: String)
+- *Default*: undef
+
+---
+#### allow_update_forwarding (type: String)
+- *Default*: undef
+
+---
+#### allow_transfer (type: String)
+- *Default*: undef
+
+---
+#### order (type: Integer)
 
 - *Default*: undef
 
-type (type: Integer)
 ---
-Value of `type` config option in a zone declaration. Valid values are 'master'
-and 'slave'.
 
-- *Default*: undef
+## Defined type `bind::zone`
 
-update_policies (type: Hash)
----
-Values for entire update-policy declaration within the zone declaration. The
-key is the target of the `grant` config option. Value 'key' is the key to be
-used for the grant and is required. Value 'matchtype' maps to the matchtype and
-is required. Value 'rrs' maps to an array of resource records and is optional.
+### Description
 
-- *Default*: undef
+/!\ TODO add description
 
-```
-# examples
-
+##### Example:
+```yaml
 bind::zones:
   'foo.example.com':
     type: 'master'
@@ -793,3 +779,48 @@ bind::zones:
         rrs:
           - 'CNAME'
 ```
+---
+
+### Parameters
+
+---
+#### target (type: String)
+Absolute path to zone list file which is the target of concat_fragment.
+
+- *Required*
+
+---
+#### tag (type: String)
+Tag to be used with concat_fragment.
+
+- *Default*: $name
+
+---
+#### extra_path (type: String)
+Optional extra path to be appended to `$bind::zones_dir`. Must be an absolute
+path.
+
+- *Default*: undef
+
+---
+#### masters (type: String)
+Value of `masters` config option in a zone declaration. If `type` is 'slave',
+this is required, else it is not used.
+
+- *Default*: undef
+
+---
+#### type (type: String)
+Value of `type` config option in a zone declaration. Valid values are 'master'
+and 'slave'.
+
+- *Default*: undef
+
+---
+#### update_policies (type: Hash)
+Values for entire update-policy declaration within the zone declaration. The
+key is the target of the `grant` config option. Value 'key' is the key to be
+used for the grant and is required. Value 'matchtype' maps to the matchtype and
+is required. Value 'rrs' maps to an array of resource records and is optional.
+
+- *Default*: undef

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 describe 'bind' do
+  let(:facts) { mandatory_facts }
+  let(:params) { mandatory_params }
+
   concats = {
     '/etc/named/channels' => { :tag => 'bind_channel', },
     '/etc/named/acls'     => { :tag => 'bind_acl', },
@@ -818,20 +821,7 @@ describe 'bind' do
   end
 
   describe 'variable type and content validations' do
-    # set needed custom facts and variables
-    let(:facts) do
-      {
-        :osfamily => 'RedHat',
-        :operatingsystem => 'RedHat',
-      }
-    end
-    # /!\ template does not support $include = undef
-    # workaround is to set $include to an empty array
-    let(:mandatory_params) do
-      {
-        #:param => 'value',
-      }
-    end
+    let(:facts) { mandatory_facts }
 
     validations = {
       'absolute_path' => {

--- a/spec/defines/acl_spec.rb
+++ b/spec/defines/acl_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'bind::acl' do
   let(:title) { 'rspec' }
+  let(:facts) { mandatory_facts }
+  let(:params) { mandatory_params }
 
   context 'with defaults for all parameters' do
     it 'should fail' do
@@ -118,17 +120,7 @@ describe 'bind::acl' do
   end
 
   describe 'variable type and content validations' do
-    # set needed custom facts and variables
-    let(:facts) do
-      {
-        #:fact => 'value',
-      }
-    end
-    let(:mandatory_params) do
-      {
-        #:param => 'value',
-      }
-    end
+    let(:facts) { mandatory_facts }
 
     validations = {
       'array' => {

--- a/spec/defines/channel_spec.rb
+++ b/spec/defines/channel_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'bind::channel' do
   let(:title) { 'rspec' }
+  let(:facts) { mandatory_facts }
+  let(:params) { mandatory_params }
 
   # $type is mandatory (nothing set)
   context 'with defaults for all parameters' do
@@ -204,16 +206,11 @@ describe 'bind::channel' do
   end
 
   describe 'variable type and content validations' do
-    # set needed custom facts and variables
-    let(:facts) do
-      {
-        #:fact => 'value',
-      }
-    end
+    let(:facts) { mandatory_facts }
     let(:mandatory_params) do
       {
-        :type => 'file',
         :file => '/absolute/path',
+        :type => 'file',
       }
     end
 
@@ -224,7 +221,6 @@ describe 'bind::channel' do
         :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
         :message => 'bind::channel::rspec::type is <.*>\. Valid values are',
       },
-      # enhancement: validate valid values for severity & syslog_facility
       'string' => {
         :name    => %w(file severity syslog_facility),
         :valid   => ['string'],

--- a/spec/defines/key_spec.rb
+++ b/spec/defines/key_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'bind::key' do
   let(:title) { 'rspec' }
+  let(:facts) { mandatory_facts }
+  let(:params) { mandatory_params }
 
   # $secret is mandatory (nothing set)
   context 'with defaults for all parameters' do
@@ -129,20 +131,10 @@ describe 'bind::key' do
   end
 
   describe 'variable type and content validations' do
-    # set needed custom facts and variables
-    let(:facts) do
-      {
-        #:fact => 'value',
-      }
-    end
-    let(:mandatory_params) do
-      {
-        :secret => 'geheim',
-      }
-    end
+    let(:facts) { mandatory_facts }
+    let(:mandatory_params) { { :secret => 'geheim' } }
 
     validations = {
-      # enhancement: validate valid values for algorithm
       'absolute_path' => {
         :name    => %w(path),
         :valid   => ['/absolute/filepath', '/absolute/directory/'],

--- a/spec/defines/masters_spec.rb
+++ b/spec/defines/masters_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'bind::masters' do
   let(:title) { 'rspec' }
+  let(:facts) { mandatory_facts }
+  let(:params) { mandatory_params }
 
   # $secret is mandatory (nothing set)
   context 'with defaults for all parameters' do
@@ -56,17 +58,7 @@ describe 'bind::masters' do
   end
 
   describe 'variable type and content validations' do
-    # set needed custom facts and variables
-    let(:facts) do
-      {
-        #:fact => 'value',
-      }
-    end
-    let(:mandatory_params) do
-      {
-        #:param => 'value',
-      }
-    end
+    let(:facts) { mandatory_facts }
 
     validations = {
       'hash' => {

--- a/spec/defines/view_spec.rb
+++ b/spec/defines/view_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'bind::view' do
   let(:title) { 'rspec' }
+  let(:facts) { mandatory_facts }
+  let(:params) { mandatory_params }
 
   context 'with defaults for all parameters' do
     content = <<-END.gsub(/^\s+\|/, '')
@@ -333,17 +335,7 @@ describe 'bind::view' do
   end
 
   describe 'variable type and content validations' do
-    # set needed custom facts and variables
-    let(:facts) do
-      {
-        #:fact => 'value',
-      }
-    end
-    let(:mandatory_params) do
-      {
-        #:param => 'value',
-      }
-    end
+    let(:facts) { mandatory_facts }
 
     validations = {
       'array' => {

--- a/spec/defines/zone_spec.rb
+++ b/spec/defines/zone_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe 'bind::zone' do
   let(:title) { 'rspec' }
+  let(:facts) { mandatory_facts }
+  let(:params) { mandatory_params }
   # realize virtual resources to allow spec testing them
   let :pre_condition do
     'Concat_fragment <| |>'
@@ -206,12 +208,7 @@ describe 'bind::zone' do
   end
 
   describe 'variable type and content validations' do
-    # set needed custom facts and variables
-    let(:facts) do
-      {
-        #:fact => 'value',
-      }
-    end
+    let(:facts) { mandatory_facts }
     let(:mandatory_params) do
       {
         :target => '/absolute/path',
@@ -220,24 +217,24 @@ describe 'bind::zone' do
     end
 
     validations = {
-      'regex for type' => {
-        :name    => %w(type),
-        :valid   => %w(master slave),
-        :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
-        :message => "bind::zone::rspec::type is <.*> and must be 'master' or 'slave'\.",
-        :params  => { :masters => 'master-spectest' },
-      },
       'absolute_path' => {
         :name    => %w(target extra_path),
         :valid   => ['/absolute/filepath', '/absolute/directory/'],
         :invalid => ['../invalid', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
         :message => 'is not an absolute path',
       },
+      'regex for type' => {
+        :name    => %w(type),
+        :params  => {:masters => 'master-spectest'},
+        :valid   => %w(master slave),
+        :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
+        :message => "bind::zone::rspec::type is <.*> and must be 'master' or 'slave'\.",
+      },
       'string' => {
         :name    => %w(tag masters),
         :valid   => ['string'],
         :invalid => [%w(array), { 'ha' => 'sh' }, 3, 2.42, true, false],
-        :message => 'is not a string',
+        :message => '(is not a string|Invalid tag)',
       },
       'hash' => {
         :name    => %w(update_policies),

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,3 +11,13 @@ RSpec.configure do |config|
     Facter.clear_messages
   end
 end
+
+def mandatory_facts
+  {
+    :parameter => nil,
+  }
+end
+
+def mandatory_params
+  {}
+end


### PR DESCRIPTION
Changed the layout to match the style from the cgroups module.
- add TOC
- add datatype where missing
- add valid values when validate_re was used

Missing:
- parameter description for $bind::forwarders
- short description for class bind
- short description for define bind::view
- short description for define bind::zone
