### PR TITLE
Add bind::zone forwarders parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,10 @@ bind::zones:
       - '10.1.1.0/24'
       - '10.1.2.3'
       - 'key name-of-key'
+    forwarders:
+      - '10.1.1.0/24'
+      - '10.1.2.3'
+      - 'key name-of-key'
 ```
 ---
 
@@ -901,6 +905,10 @@ is required. Value 'rrs' maps to an array of resource records and is optional.
 - *Default*: undef
 
 ---
-#### allow_update (type: Array)
+#### allow_updates (type: Array)
 Values for allow-update declaration within the zone declaration. This is
 mutually exclusive with update_policies.
+
+---
+#### forwarders (type: Array)
+Values for forwarders declaration within the zone declaration.

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -33,6 +33,7 @@ define bind::zone (
   $type            = undef, # master or slave
   $update_policies = undef, # mutually exclusive with allow_update
   $allow_update    = undef,
+  $forwarders      = undef,
 ) {
 
   include ::bind
@@ -80,6 +81,11 @@ define bind::zone (
 
   if $allow_update != undef {
     validate_array($allow_update)
+  }
+
+  # Same behavior as allow_update, Array of Strings.
+  if $forwarders != undef {
+    validate_array($forwarders)
   }
 
   if $allow_update != undef and $update_policies != undef {

--- a/spec/defines/zone_spec.rb
+++ b/spec/defines/zone_spec.rb
@@ -23,6 +23,7 @@ describe 'bind::zone' do
         :target     => '/etc/named/zone_lists/internal.zones',
         :extra_path => '/internal',
         :masters    => 'master-internal',
+        :forwarders => ['192.168.0.4', '192.168.0.5'],
         :type       => 'slave',
       }
     end
@@ -34,6 +35,7 @@ describe 'bind::zone' do
       |  type slave;
       |  masters { master-internal; };
       |  file "slaves/internal/rspec";
+      |  forwarders { 192.168.0.4; 192.168.0.5; };
       |};
     END
 
@@ -292,6 +294,68 @@ describe 'bind::zone' do
         |  masters { master-internal; };
         |  allow-update { 10.1.2.3; 10.1.1.0/24; key "my-key-name"; };
         |  file "slaves/internal/rspec";
+        |};
+      END
+
+      it do
+        should contain_file('/etc/named/zones.d/internal/rspec').with({
+          'content' => content,
+        })
+      end
+    end
+  end
+
+  describe 'with forwarders set' do
+    context 'to an array with one element' do
+      let(:params) do
+        {
+          :target     => '/etc/named/zone_lists/internal.zones',
+          :extra_path => '/internal',
+          :masters    => 'master-internal',
+          :type       => 'slave',
+          :forwarders => ['10.1.2.3'],
+        }
+      end
+
+      content = <<-END.gsub(/^\s+\|/, '')
+        |# This file is being maintained by Puppet.
+        |# DO NOT EDIT
+        |
+        |zone "rspec" {
+        |  type slave;
+        |  masters { master-internal; };
+        |  file "slaves/internal/rspec";
+        |  forwarders { 10.1.2.3; };
+        |};
+      END
+
+      it do
+        should contain_file('/etc/named/zones.d/internal/rspec').with({
+          'content' => content,
+        })
+      end
+    end
+
+    context 'to an array of multiple elements' do
+      let(:params) do
+        {
+          :target       => '/etc/named/zone_lists/internal.zones',
+          :extra_path   => '/internal',
+          :masters      => 'master-internal',
+          :type         => 'slave',
+          :forwarders => ['10.1.2.3', '10.1.1.0/24', 'key my-key-name'],
+        }
+      end
+
+      content = <<-END.gsub(/^\s+\|/, '')
+        |# This file is being maintained by Puppet.
+        |# DO NOT EDIT
+        |
+        |zone "rspec" {
+        |  type slave;
+        |  masters { master-internal; };
+        |  file "slaves/internal/rspec";
+        |  forwarders { 10.1.2.3; 10.1.1.0/24; key "my-key-name"; };
         |};
       END
 

--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -19,6 +19,18 @@ zone "<%= @zone %>" {
   allow-update { <%= au.join('; ') %>; };
 <% end -%>
   file "<%= @dir %><% if not @extra_path.nil? -%><%= @extra_path %><% end -%>/<%= @zone %>";
+<% if @forwarders -%>
+<%   fwlst = Array.new -%>
+<%   @forwarders.each do |i| -%>
+<%     if i =~ /^key/ -%>
+<%       # add quotes around name of key -%>
+<%       fwlst << "key \"#{i.split[1]}\"" -%>
+<%     else -%>
+<%       fwlst << i -%>
+<%     end -%>
+<%   end -%>
+  forwarders { <%= fwlst.join('; ') %>; };
+<% end -%>
 <% if not @update_policies.nil? -%>
 
   update-policy


### PR DESCRIPTION
Without this patch a zone cannot be configured with a forward zone. This patch
adds the zone forwarders parameter, modeled on the allow-updates parameter.