### PR TITLE
Allow for an empty forwarders section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,12 @@ Value of `recursion` option in named.conf.
 
 ---
 #### forwarders (type: Array)
-Value of `forwarders` option in named.conf.
+Value of `forwarders` option in named.conf. If you specify an array with
+a single value of 'empty' it will generate an empty forwarders section.
+
+```
+forwarders {};
+```
 
 - *Default*: undef
 
@@ -909,6 +914,16 @@ is required. Value 'rrs' maps to an array of resource records and is optional.
 Values for allow-update declaration within the zone declaration. This is
 mutually exclusive with update_policies.
 
+- *Default*: undef
+
 ---
 #### forwarders (type: Array)
-Values for forwarders declaration within the zone declaration.
+Values for forwarders declaration within the zone declaration. If you
+specify an array with a single value of 'empty' it will generate an
+empty forwarders section.
+
+```
+forwarders {};
+```
+
+- *Default*: undef

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -340,16 +340,22 @@ describe 'bind' do
     it { should contain_file('named_conf').with_content(/^options \{(\n.*)*^\s*recursion yes;(\n.*)*\};/) }
   end
 
-  context 'with forwarders set to valid array [10.0.0.242]' do
+  context "with forwarders set to valid array ['10.0.0.242']" do
     let(:params) { { :forwarders => %w(10.0.0.242) } }
 
     it { should contain_file('named_conf').with_content(/^  forwarders { 10.0.0.242; };/) }
   end
 
-  context 'with forwarders set to valid array [10.0.0.3 10.0.0.242]' do
+  context "with forwarders set to valid array ['10.0.0.3', '10.0.0.242']" do
     let(:params) { { :forwarders => %w(10.0.0.3 10.0.0.242) } }
 
     it { should contain_file('named_conf').with_content(/^  forwarders { 10.0.0.3; 10.0.0.242; };/) }
+  end
+
+  context "with forwarders set to valid array ['empty']" do
+    let(:params) { { :forwarders => %w(empty) } }
+
+    it { should contain_file('named_conf').with_content(/^  forwarders {};/) }
   end
 
   context 'with zone_statistics set to valid string <no>' do

--- a/spec/defines/zone_spec.rb
+++ b/spec/defines/zone_spec.rb
@@ -365,6 +365,65 @@ describe 'bind::zone' do
         })
       end
     end
+
+    context "to an array with one element set to 'empty'" do
+      let(:params) do
+        {
+          :target     => '/etc/named/zone_lists/internal.zones',
+          :extra_path => '/internal',
+          :masters    => 'master-internal',
+          :type       => 'slave',
+          :forwarders => ['empty'],
+        }
+      end
+
+      content = <<-END.gsub(/^\s+\|/, '')
+        |# This file is being maintained by Puppet.
+        |# DO NOT EDIT
+        |
+        |zone "rspec" {
+        |  type slave;
+        |  masters { master-internal; };
+        |  file "slaves/internal/rspec";
+        |  forwarders {};
+        |};
+      END
+
+      it do
+        should contain_file('/etc/named/zones.d/internal/rspec').with({
+          'content' => content,
+        })
+      end
+    end
+
+    context 'to undef' do
+      let(:params) do
+        {
+          :target     => '/etc/named/zone_lists/internal.zones',
+          :extra_path => '/internal',
+          :masters    => 'master-internal',
+          :type       => 'slave',
+          :forwarders => :undef,
+        }
+      end
+
+      content = <<-END.gsub(/^\s+\|/, '')
+        |# This file is being maintained by Puppet.
+        |# DO NOT EDIT
+        |
+        |zone "rspec" {
+        |  type slave;
+        |  masters { master-internal; };
+        |  file "slaves/internal/rspec";
+        |};
+      END
+
+      it do
+        should contain_file('/etc/named/zones.d/internal/rspec').with({
+          'content' => content,
+        })
+      end
+    end
   end
 
   describe 'variable type and content validations' do

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -17,8 +17,12 @@ options {
   dump-file "<%= @dump_file %>";
   statistics-file "<%= @statistics_file %>";
   memstatistics-file "<%= @memstatistics_file %>";
-  <%- if not @forwarders.nil? -%>
+  <%- if @forwarders -%>
+  <%-   if @forwarders == ['empty'] -%>
+  forwarders {};
+  <%-   else -%>
   forwarders { <%= @forwarders.join('; ') -%>; };
+  <%-   end -%>
   <%- end -%>
 };
 

--- a/templates/zone.erb
+++ b/templates/zone.erb
@@ -20,16 +20,20 @@ zone "<%= @zone %>" {
 <% end -%>
   file "<%= @dir %><% if not @extra_path.nil? -%><%= @extra_path %><% end -%>/<%= @zone %>";
 <% if @forwarders -%>
-<%   fwlst = Array.new -%>
-<%   @forwarders.each do |i| -%>
-<%     if i =~ /^key/ -%>
-<%       # add quotes around name of key -%>
-<%       fwlst << "key \"#{i.split[1]}\"" -%>
-<%     else -%>
-<%       fwlst << i -%>
+<%   if @forwarders == ['empty'] -%>
+  forwarders {};
+<%   else -%>
+<%     fwlst = Array.new -%>
+<%     @forwarders.each do |i| -%>
+<%       if i =~ /^key/ -%>
+<%         # add quotes around name of key -%>
+<%         fwlst << "key \"#{i.split[1]}\"" -%>
+<%       else -%>
+<%         fwlst << i -%>
+<%       end -%>
 <%     end -%>
-<%   end -%>
   forwarders { <%= fwlst.join('; ') %>; };
+<%   end -%>
 <% end -%>
 <% if not @update_policies.nil? -%>
 


### PR DESCRIPTION
Without this patch, it is not possible to have an empty forwarders
section such as the following. This is needed when setting global
forwarders in the named.conf and then undefining them in a zone.

  forwarders {};